### PR TITLE
export only ModuleSwitcher stateless function component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cerebral-modules-react",
-  "version": "0.3.0",
-  "description": "A library for rendering cerebral modules",
+  "version": "0.4.0",
+  "description": "A module switcher component for cerebral",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint src test",
@@ -30,7 +30,6 @@
     "babel": "^5.8.34",
     "babel-eslint": "^4.1.6",
     "cerebral": "^0.26.1",
-    "cerebral-modules": "^0.3.0",
     "cerebral-react": "^0.8.0",
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
@@ -43,7 +42,6 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "cerebral-modules": "^0.3.0",
     "cerebral-react": "^0.8.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,36 @@
-import React, { Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
-import { Container, Decorator as State } from 'cerebral-react';
-import { _getModules } from 'cerebral-modules';
+import React, { PropTypes } from 'react';
+import Component from 'cerebral-react'
 
-@State({
-  activeModule: ['activeModule']
-})
-class ModuleSwitch extends Component {
+const ModuleSwitch = (props) => {
+  const {
+    activeModule,
+    modules
+  } = props;
 
-  static displayName = 'ModuleSwitch';
+  const loadingComponent = props.loadingComponent || 'Loading...';
+  const notFoundComponent = props.notFoundComponent || `No component found for ${activeModule} module`;
 
-  static propTypes = {
-    activeModule: PropTypes.string
-  };
-
-  render() {
-    const {
-      activeModule
-    } = this.props;
-
-    if (!activeModule) {
-      return (
-        <div>Loading...</div>
-      );
-    }
-
-    const modules = _getModules();
-    const ModuleComponent = modules[activeModule] && modules[activeModule].Component;
-
-    return ModuleComponent ? (
-      <ModuleComponent/>
-    ) : (
-      <div>No component found for {activeModule} module</div>
-    );
+  if (!activeModule) {
+    return (<div>{ loadingComponent }</div>);
   }
-}
 
-export default function render(controller) {
-  // start the app
-  const container = document.body.appendChild(document.createElement('div'));
-  ReactDOM.render(<Container controller={controller} app={ModuleSwitch}/>, container);
-}
+  const ModuleComponent = modules[activeModule] && modules[activeModule].Component;
+
+  return ModuleComponent ? (
+    // see https://github.com/cerebral/cerebral-react/issues/15
+    <ModuleComponent basePath={[activeModule]} />
+  ) : (
+    <div>{ notFoundComponent }</div>
+  );
+};
+
+ModuleSwitch.propTypes = {
+  activeModule: PropTypes.string,
+  loadingComponent: PropTypes.node,
+  modules: PropTypes.object,
+  notFoundComponent: PropTypes.node
+};
+
+export default Component(ModuleSwitch, {
+  activeModule: ['activeModule']
+});


### PR DESCRIPTION
I am pretty sure we do not need `render` function. App most likely would have some top-level app container with navigation, sidebar, footers and other stuff. So let just provide stateless switcher component which accepts current module name and object with mapped Components.
